### PR TITLE
Improve URL analyzer webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,14 @@ For security issues, please see [SECURITY.md](SECURITY.md) for detailed informat
 - Check the logs in `server.log`
 - Review [SECURITY.md](SECURITY.md) for security-related questions
 - Open an issue on GitHub for bugs or feature requests
+
+## URL Analyzer Webapp
+
+Run `url_analyzer_app.py` to analyze the tone and subtext of any webpage.
+
+```bash
+pip install Flask requests beautifulsoup4 textblob
+python url_analyzer_app.py
+```
+
+Visit <http://localhost:5010/> in your browser and submit a URL.

--- a/templates/url_analyzer.html
+++ b/templates/url_analyzer.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>URL Analyzer</title>
+<h1>Analyze URL Content</h1>
+<form method="post">
+  <input name="url" placeholder="Enter URL" style="width: 300px;">
+  <input type="submit" value="Analyze">
+</form>
+{% if result %}
+  <h2>Results for {{ result.url }}</h2>
+  {% if result.error %}
+    <p style='color:red;'>Error: {{ result.error }}</p>
+  {% else %}
+    <p><strong>Polarity:</strong> {{ result.polarity }}</p>
+    <p><strong>Subjectivity:</strong> {{ result.subjectivity }}</p>
+    <p><strong>Tone:</strong> {{ result.tone }}</p>
+    <p><strong>Emotion:</strong> {{ result.emotion }}</p>
+    <p><strong>Subtext:</strong> {{ result.subtext }}</p>
+  {% endif %}
+{% endif %}
+

--- a/url_analyzer_app.py
+++ b/url_analyzer_app.py
@@ -1,0 +1,56 @@
+import requests
+from bs4 import BeautifulSoup
+from flask import Flask, request, render_template
+from textblob import TextBlob
+
+app = Flask(__name__)
+
+def analyze_text(text: str) -> dict:
+    blob = TextBlob(text)
+    polarity = blob.sentiment.polarity
+    subjectivity = blob.sentiment.subjectivity
+
+    if polarity > 0.1:
+        tone = "positive"
+    elif polarity < -0.1:
+        tone = "negative"
+    else:
+        tone = "neutral"
+
+    if subjectivity > 0.5:
+        emotion = "subjective or emotional"
+    else:
+        emotion = "objective or neutral"
+
+    lower_text = text.lower()
+    if "not intended" in lower_text or "no guarantee" in lower_text:
+        subtext = "Possible disclaimer or hidden warning"
+    else:
+        subtext = "No obvious subtext"
+
+    return {
+        "polarity": round(polarity, 3),
+        "subjectivity": round(subjectivity, 3),
+        "tone": tone,
+        "emotion": emotion,
+        "subtext": subtext,
+    }
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    result = None
+    if request.method == "POST":
+        url = request.form.get("url", "")
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            soup = BeautifulSoup(resp.text, "html.parser")
+            text = soup.get_text(separator=" ", strip=True)
+            result = analyze_text(text[:5000])
+            result["url"] = url
+        except Exception as e:
+            result = {"error": str(e), "url": url}
+    return render_template("url_analyzer.html", result=result)
+
+if __name__ == "__main__":
+    app.run(port=5010, debug=True)


### PR DESCRIPTION
## Summary
- add Jinja template `url_analyzer.html`
- update `url_analyzer_app.py` to use `render_template`
- document how to run the URL analyzer app

## Testing
- `python -m py_compile url_analyzer_app.py`
- `nohup python url_analyzer_app.py > /tmp/server.log 2>&1 &`
- `curl -s http://localhost:5010/ | head -n 5`
- `curl -s -X POST -d "url=https://example.com" http://localhost:5010/ | head -n 12`
- `python -m webbrowser http://localhost:5010/`


------
https://chatgpt.com/codex/tasks/task_e_685a3cce1c2883258baa3e23ca13f6d5

## Summary by Sourcery

Implement a new web interface using Flask and Jinja2 to analyze webpage tone, subjectivity, and subtext via TextBlob, and document the setup process

New Features:
- Implement a Flask-based URL Analyzer webapp to fetch, parse, and analyze webpage sentiment and subtext
- Add a Jinja2 template for user input and result display

Documentation:
- Update README with installation steps and usage instructions for the URL Analyzer webapp