### PR TITLE
Improve README for local site viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # christcame.github.io
-x
+
+This repository contains the source files for my personal static website hosted on GitHub Pages. The site is made up of HTML, CSS, and image assets—no build step is required.
+
+## Viewing the Site Locally
+1. Ensure Python is installed.
+2. From the project root, run:
+   ```
+   python -m http.server
+   ```
+3. Open `http://localhost:8000` in your web browser to view the site.
+
+## Deployment
+Updates pushed to the **main** branch are automatically published via GitHub Pages. Commit your changes and push to deploy.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ This repository contains the source files for my personal static website hosted 
 1. Ensure Python is installed.
 2. From the project root, run:
    ```
-   python -m http.server
+   python -m http.server 8000
    ```
-3. Open `http://localhost:8000` in your web browser to view the site.
+   The command serves the site on port 8000.
+3. Visit `http://localhost:8000` in your browser to view the pages.
+4. Stop the server with `Ctrl+C` when you are done.
 
 ## Deployment
 Updates pushed to the **main** branch are automatically published via GitHub Pages. Commit your changes and push to deploy.


### PR DESCRIPTION
## Summary
- document how to view the static site locally with `python -m http.server`
- note deployment to GitHub Pages

## Testing
- `python -m http.server 8000` *(served site)*
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_685a78d624a48325aa9a00ae242f3ffa

## Summary by Sourcery

Improve the repository README by describing its contents, adding local viewing steps, and detailing GitHub Pages deployment.

Documentation:
- Clarify that the site is a static HTML/CSS project with no build step
- Add instructions for serving the site locally using Python’s HTTP server
- Document automatic publication of the main branch via GitHub Pages